### PR TITLE
Allow developers to define #call with arguments for convenience

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,3 +43,5 @@ Style/StringLiterals:
   EnforcedStyle: double_quotes
 Style/SymbolArray:
   Enabled: false
+Style/WordArray:
+  Enabled: false

--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -166,24 +166,22 @@ module Interactor
 
   private
 
-  # Internal: Determine what arguments (if any) should be passed to the "call"
-  # instance method when invoking an Interactor. The "call" instance method may
-  # accept any combination of positional and keyword arguments. This method
-  # will extract values from the context in order to populate those arguments
-  # based on their names.
+  # Internal: Determine what keyword arguments (if any) should be passed to the
+  # "call" instance method when invoking an Interactor. The "call" instance
+  # method may accept any number of keyword arguments. This method will extract
+  # values from the context in order to populate those arguments based on their
+  # names.
   #
   # Returns an Array of arguments to be applied as an argument list.
-  def arguments_for_call # rubocop:disable Metrics/MethodLength
+  def arguments_for_call
     positional_arguments = []
     keyword_arguments = {}
 
     method(:call).parameters.each do |(type, name)|
+      next unless type == :keyreq || type == :key
       next unless context.include?(name)
 
-      case type
-      when :req, :opt then positional_arguments << context[name]
-      when :keyreq, :key then keyword_arguments[name] = context[name]
-      end
+      keyword_arguments[name] = context[name]
     end
 
     positional_arguments << keyword_arguments if keyword_arguments.any?

--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -173,18 +173,16 @@ module Interactor
   # based on their names.
   #
   # Returns an Array of arguments to be applied as an argument list.
-  def arguments_for_call
-    positional_arguments, keyword_arguments = [], {}
-    available_context_keys = context.to_h.keys
+  def arguments_for_call # rubocop:disable Metrics/MethodLength
+    positional_arguments = []
+    keyword_arguments = {}
 
     method(:call).parameters.each do |(type, name)|
-      next unless available_context_keys.include?(name)
+      next unless context.include?(name)
 
       case type
-      when :req, :opt
-        positional_arguments << context[name]
-      when :keyreq, :key
-        keyword_arguments[name] = context[name]
+      when :req, :opt then positional_arguments << context[name]
+      when :keyreq, :key then keyword_arguments[name] = context[name]
       end
     end
 

--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -158,6 +158,15 @@ module Interactor
       @rolled_back = true
     end
 
+    # Public: Check for the presence of a given key in the context. This does
+    # not check whether the value is truthy, just whether the key is set to any
+    # value at all.
+    #
+    # Returns true if the key is found or false otherwise.
+    def include?(key)
+      table.include?(key.to_sym)
+    end
+
     # Internal: An Array of successfully called Interactor instances invoked
     # against this Interactor::Context instance.
     #

--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -121,7 +121,7 @@ module Interactor
     #
     # Raises Interactor::Failure initialized with the Interactor::Context.
     def fail!(context = {})
-      context.each { |key, value| self[key.to_sym] = value }
+      context.each { |key, value| self[key] = value }
       @failure = true
       raise Failure, self
     end

--- a/spec/interactor/context_spec.rb
+++ b/spec/interactor/context_spec.rb
@@ -190,6 +190,26 @@ module Interactor
       end
     end
 
+    describe "#include?" do
+      it "returns true if the key is found" do
+        context = Context.build(foo: "bar")
+
+        expect(context.include?(:foo)).to eq(true)
+      end
+
+      it "returns true if the symbolized key is found" do
+        context = Context.build(foo: "bar")
+
+        expect(context.include?("foo")).to eq(true)
+      end
+
+      it "returns false if the key is not found" do
+        context = Context.build(foo: "bar")
+
+        expect(context.include?(:hello)).to eq(false)
+      end
+    end
+
     describe "#_called" do
       let(:context) { Context.build }
 

--- a/spec/interactor_spec.rb
+++ b/spec/interactor_spec.rb
@@ -1,3 +1,213 @@
 describe Interactor do
   include_examples :lint
+
+  describe "#call" do
+    let(:interactor) { Class.new.send(:include, described_class) }
+
+    context "positional arguments" do
+      it "accepts required positional arguments" do
+        interactor.class_eval do
+          def call(foo)
+            context.output = foo
+          end
+        end
+
+        result = interactor.call(foo: "baz", hello: "world")
+
+        expect(result.output).to eq("baz")
+      end
+
+      it "accepts optional positional arguments" do
+        interactor.class_eval do
+          def call(foo = "bar")
+            context.output = foo
+          end
+        end
+
+        result = interactor.call(foo: "baz", hello: "world")
+
+        expect(result.output).to eq("baz")
+      end
+
+      it "assigns absent positional arguments" do
+        interactor.class_eval do
+          def call(foo = "bar")
+            context.output = foo
+          end
+        end
+
+        result = interactor.call(hello: "world")
+
+        expect(result.output).to eq("bar")
+      end
+
+      it "raises an error for missing positional arguments" do
+        interactor.class_eval do
+          def call(foo)
+            context.output = foo
+          end
+        end
+
+        expect { interactor.call(hello: "world") }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "keyword arguments" do
+      it "accepts required keyword arguments" do
+        interactor.class_eval do
+          def call(foo:)
+            context.output = foo
+          end
+        end
+
+        result = interactor.call(foo: "baz", hello: "world")
+
+        expect(result.output).to eq("baz")
+      end
+
+      it "accepts optional keyword arguments" do
+        interactor.class_eval do
+          def call(foo: "bar")
+            context.output = foo
+          end
+        end
+
+        result = interactor.call(foo: "baz", hello: "world")
+
+        expect(result.output).to eq("baz")
+      end
+
+      it "assigns absent keyword arguments" do
+        interactor.class_eval do
+          def call(foo: "bar")
+            context.output = foo
+          end
+        end
+
+        result = interactor.call(hello: "world")
+
+        expect(result.output).to eq("bar")
+      end
+
+      it "raises an error for missing keyword arguments" do
+        interactor.class_eval do
+          def call(foo:)
+            context.output = foo
+          end
+        end
+
+        expect { interactor.call(hello: "world") }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "combination arguments" do
+      it "accepts required positional with required keyword arguments" do
+        interactor.class_eval do
+          def call(foo, hello:)
+            context.output = [foo, hello]
+          end
+        end
+
+        result = interactor.call(foo: "baz", hello: "world")
+
+        expect(result.output).to eq(["baz", "world"])
+      end
+
+      it "accepts required positional with optional keyword arguments" do
+        interactor.class_eval do
+          def call(foo, hello: "there")
+            context.output = [foo, hello]
+          end
+        end
+
+        result = interactor.call(foo: "baz", hello: "world")
+
+        expect(result.output).to eq(["baz", "world"])
+      end
+
+      it "accepts required positional and assigns absent keyword arguments" do
+        interactor.class_eval do
+          def call(foo, hello: "there")
+            context.output = [foo, hello]
+          end
+        end
+
+        result = interactor.call(foo: "baz")
+
+        expect(result.output).to eq(["baz", "there"])
+      end
+
+      it "accepts optional positional with required keyword arguments" do
+        interactor.class_eval do
+          def call(foo = "bar", hello:)
+            context.output = [foo, hello]
+          end
+        end
+
+        result = interactor.call(foo: "baz", hello: "world")
+
+        expect(result.output).to eq(["baz", "world"])
+      end
+
+      it "accepts optional positional with optional keyword arguments" do
+        interactor.class_eval do
+          def call(foo = "bar", hello: "there")
+            context.output = [foo, hello]
+          end
+        end
+
+        result = interactor.call(foo: "baz", hello: "world")
+
+        expect(result.output).to eq(["baz", "world"])
+      end
+
+      it "accepts optional positional and assigns absent keyword arguments" do
+        interactor.class_eval do
+          def call(foo = "bar", hello: "there")
+            context.output = [foo, hello]
+          end
+        end
+
+        result = interactor.call(foo: "baz")
+
+        expect(result.output).to eq(["baz", "there"])
+      end
+
+      it "assigns absent positional and accepts required keyword arguments" do
+        interactor.class_eval do
+          def call(foo = "bar", hello:)
+            context.output = [foo, hello]
+          end
+        end
+
+        result = interactor.call(hello: "world")
+
+        expect(result.output).to eq(["bar", "world"])
+      end
+
+      it "assigns absent positional and accepts optional keyword arguments" do
+        interactor.class_eval do
+          def call(foo = "bar", hello: "there")
+            context.output = [foo, hello]
+          end
+        end
+
+        result = interactor.call(hello: "world")
+
+        expect(result.output).to eq(["bar", "world"])
+      end
+
+      it "assigns absent positional and absent keyword arguments" do
+        interactor.class_eval do
+          def call(foo = "bar", hello: "there")
+            context.output = [foo, hello]
+          end
+        end
+
+        result = interactor.call
+
+        expect(result.output).to eq(["bar", "there"])
+      end
+    end
+  end
 end

--- a/spec/interactor_spec.rb
+++ b/spec/interactor_spec.rb
@@ -4,54 +4,6 @@ describe Interactor do
   describe "#call" do
     let(:interactor) { Class.new.send(:include, described_class) }
 
-    context "positional arguments" do
-      it "accepts required positional arguments" do
-        interactor.class_eval do
-          def call(foo)
-            context.output = foo
-          end
-        end
-
-        result = interactor.call(foo: "baz", hello: "world")
-
-        expect(result.output).to eq("baz")
-      end
-
-      it "accepts optional positional arguments" do
-        interactor.class_eval do
-          def call(foo = "bar")
-            context.output = foo
-          end
-        end
-
-        result = interactor.call(foo: "baz", hello: "world")
-
-        expect(result.output).to eq("baz")
-      end
-
-      it "assigns absent positional arguments" do
-        interactor.class_eval do
-          def call(foo = "bar")
-            context.output = foo
-          end
-        end
-
-        result = interactor.call(hello: "world")
-
-        expect(result.output).to eq("bar")
-      end
-
-      it "raises an error for missing positional arguments" do
-        interactor.class_eval do
-          def call(foo)
-            context.output = foo
-          end
-        end
-
-        expect { interactor.call(hello: "world") }.to raise_error(ArgumentError)
-      end
-    end
-
     context "keyword arguments" do
       it "accepts required keyword arguments" do
         interactor.class_eval do
@@ -60,9 +12,9 @@ describe Interactor do
           end
         end
 
-        result = interactor.call(foo: "baz", hello: "world")
+        result = interactor.call(foo: "bar", hello: "world")
 
-        expect(result.output).to eq("baz")
+        expect(result.output).to eq("bar")
       end
 
       it "accepts optional keyword arguments" do
@@ -98,115 +50,15 @@ describe Interactor do
 
         expect { interactor.call(hello: "world") }.to raise_error(ArgumentError)
       end
-    end
 
-    context "combination arguments" do
-      it "accepts required positional with required keyword arguments" do
+      it "raises an error for call definitions with non-keyword arguments" do
         interactor.class_eval do
-          def call(foo, hello:)
-            context.output = [foo, hello]
+          def call(foo)
+            context.output = foo
           end
         end
 
-        result = interactor.call(foo: "baz", hello: "world")
-
-        expect(result.output).to eq(["baz", "world"])
-      end
-
-      it "accepts required positional with optional keyword arguments" do
-        interactor.class_eval do
-          def call(foo, hello: "there")
-            context.output = [foo, hello]
-          end
-        end
-
-        result = interactor.call(foo: "baz", hello: "world")
-
-        expect(result.output).to eq(["baz", "world"])
-      end
-
-      it "accepts required positional and assigns absent keyword arguments" do
-        interactor.class_eval do
-          def call(foo, hello: "there")
-            context.output = [foo, hello]
-          end
-        end
-
-        result = interactor.call(foo: "baz")
-
-        expect(result.output).to eq(["baz", "there"])
-      end
-
-      it "accepts optional positional with required keyword arguments" do
-        interactor.class_eval do
-          def call(foo = "bar", hello:)
-            context.output = [foo, hello]
-          end
-        end
-
-        result = interactor.call(foo: "baz", hello: "world")
-
-        expect(result.output).to eq(["baz", "world"])
-      end
-
-      it "accepts optional positional with optional keyword arguments" do
-        interactor.class_eval do
-          def call(foo = "bar", hello: "there")
-            context.output = [foo, hello]
-          end
-        end
-
-        result = interactor.call(foo: "baz", hello: "world")
-
-        expect(result.output).to eq(["baz", "world"])
-      end
-
-      it "accepts optional positional and assigns absent keyword arguments" do
-        interactor.class_eval do
-          def call(foo = "bar", hello: "there")
-            context.output = [foo, hello]
-          end
-        end
-
-        result = interactor.call(foo: "baz")
-
-        expect(result.output).to eq(["baz", "there"])
-      end
-
-      it "assigns absent positional and accepts required keyword arguments" do
-        interactor.class_eval do
-          def call(foo = "bar", hello:)
-            context.output = [foo, hello]
-          end
-        end
-
-        result = interactor.call(hello: "world")
-
-        expect(result.output).to eq(["bar", "world"])
-      end
-
-      it "assigns absent positional and accepts optional keyword arguments" do
-        interactor.class_eval do
-          def call(foo = "bar", hello: "there")
-            context.output = [foo, hello]
-          end
-        end
-
-        result = interactor.call(hello: "world")
-
-        expect(result.output).to eq(["bar", "world"])
-      end
-
-      it "assigns absent positional and absent keyword arguments" do
-        interactor.class_eval do
-          def call(foo = "bar", hello: "there")
-            context.output = [foo, hello]
-          end
-        end
-
-        result = interactor.call
-
-        expect(result.output).to eq(["bar", "there"])
+        expect { interactor.call(foo: "bar") }.to raise_error(ArgumentError)
       end
     end
   end


### PR DESCRIPTION
Port of https://github.com/collectiveidea/interactor/pull/135.

Required because of how outdated the upstream `v4` branch is, this is basically the same PR but rebased onto the updated `v4` branch.