### PR TITLE
Replace raise with throw to handle context failure

### DIFF
--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -112,8 +112,17 @@ module Interactor
   #
   # Returns nothing.
   def run
-    run!
-  rescue Failure
+    catch(:early_return) do
+      with_hooks do
+        call(*arguments_for_call)
+        context.called!(self)
+      end
+    end
+    
+    context.rollback! if context.failure?
+  rescue
+    context.rollback!
+    raise
   end
 
   # Internal: Invoke an Interactor instance along with all defined hooks. The
@@ -139,13 +148,8 @@ module Interactor
   # Returns nothing.
   # Raises Interactor::Failure if the context is failed.
   def run!
-    with_hooks do
-      call(*arguments_for_call)
-      context.called!(self)
-    end
-  rescue
-    context.rollback!
-    raise
+    run
+    raise(Failure, context) if context.failure?
   end
 
   # Public: Invoke an Interactor instance without any hooks, tracking, or

--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -123,6 +123,10 @@ module Interactor
     def fail!(context = {})
       context.each { |key, value| self[key] = value }
       @failure = true
+      signal_early_return!
+    end
+
+    def signal_early_return!
       throw :early_return
     end
 

--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -123,7 +123,7 @@ module Interactor
     def fail!(context = {})
       context.each { |key, value| self[key] = value }
       @failure = true
-      raise Failure, self
+      throw :early_return
     end
 
     # Internal: Track that an Interactor has been called. The "called!" method

--- a/lib/interactor/organizer.rb
+++ b/lib/interactor/organizer.rb
@@ -8,7 +8,7 @@ module Interactor
   #   class MyOrganizer
   #     include Interactor::Organizer
   #
-  #     organizer InteractorOne, InteractorTwo
+  #     organize InteractorOne, InteractorTwo
   #   end
   module Organizer
     # Internal: Install Interactor::Organizer's behavior in the given class.
@@ -77,7 +77,8 @@ module Interactor
       # Returns nothing.
       def call
         self.class.organized.each do |interactor|
-          interactor.call!(context)
+          throw(:early_return) if context.failure?
+          interactor.call(context)
         end
       end
     end

--- a/lib/interactor/organizer.rb
+++ b/lib/interactor/organizer.rb
@@ -77,7 +77,7 @@ module Interactor
       # Returns nothing.
       def call
         self.class.organized.each do |interactor|
-          throw(:early_return) if context.failure?
+          context.signal_early_return! if context.failure?
           interactor.call(context)
         end
       end

--- a/spec/interactor/context_spec.rb
+++ b/spec/interactor/context_spec.rb
@@ -16,7 +16,7 @@ module Interactor
       end
 
       it "doesn't affect the original hash" do
-        hash = {foo: "bar"}
+        hash = { foo: "bar" }
         context = Context.build(hash)
 
         expect(context).to be_a(Context)
@@ -137,16 +137,10 @@ module Interactor
         }.from("bar").to("baz")
       end
 
-      it "raises failure" do
+      it "throws :early_return" do
         expect {
           context.fail!
-        }.to raise_error(Failure)
-      end
-
-      it "makes the context available from the failure" do
-        context.fail!
-      rescue Failure => error
-        expect(error.context).to eq(context)
+        }.to throw_symbol(:early_return)
       end
     end
 

--- a/spec/interactor/organizer_spec.rb
+++ b/spec/interactor/organizer_spec.rb
@@ -65,11 +65,12 @@ module Interactor
         instance.call
       end
 
-      it "throws :early_return on failure of one of organizers" do
+      it "signals about early_return on failure of one of organizers" do
         allow(context).to receive(:failure?).and_return(false, true)
+        expect(context).to receive(:signal_early_return!).and_throw(:foo)
         expect {
           instance.call
-        }.to throw_symbol(:early_return)
+        }.to throw_symbol
       end
     end
   end

--- a/spec/interactor/organizer_spec.rb
+++ b/spec/interactor/organizer_spec.rb
@@ -43,24 +43,33 @@ module Interactor
 
     describe "#call" do
       let(:instance) { organizer.new }
-      let(:context) { double(:context) }
+      let(:context) { double(:context, failure?: false) }
       let(:interactor2) { double(:interactor2) }
       let(:interactor3) { double(:interactor3) }
       let(:interactor4) { double(:interactor4) }
+      let(:organized_interactors) { [interactor2, interactor3, interactor4] }
 
       before do
         allow(instance).to receive(:context) { context }
-        allow(organizer).to receive(:organized) {
-          [interactor2, interactor3, interactor4]
-        }
+        allow(organizer).to receive(:organized) { organized_interactors }
+        organized_interactors.each do |organized_interactor|
+          allow(organized_interactor).to receive(:call)
+        end
       end
 
       it "calls each interactor in order with the context" do
-        expect(interactor2).to receive(:call!).once.with(context).ordered
-        expect(interactor3).to receive(:call!).once.with(context).ordered
-        expect(interactor4).to receive(:call!).once.with(context).ordered
+        expect(interactor2).to receive(:call).once.with(context).ordered
+        expect(interactor3).to receive(:call).once.with(context).ordered
+        expect(interactor4).to receive(:call).once.with(context).ordered
 
         instance.call
+      end
+
+      it "throws :early_return on failure of one of organizers" do
+        allow(context).to receive(:failure?).and_return(false, true)
+        expect {
+          instance.call
+        }.to throw_symbol(:early_return)
       end
     end
   end


### PR DESCRIPTION
Port of https://github.com/collectiveidea/interactor/pull/133.

Required because of how outdated the upstream `v4` branch is, this is basically the same PR but rebased onto the updated `v4` branch.